### PR TITLE
optional node name for check_rabbitmq_server

### DIFF
--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -46,6 +46,9 @@ $p->add_arg(spec => 'port|p=i',
     help => "Specify the port to connect to (default: %s)",
     default => 55672
 );
+$p->add_arg(spec => 'node|n=s',
+    help => "Specify the node name (default is hostname)"
+);
 
 $p->add_arg(
     spec => 'warning|w=s',
@@ -91,11 +94,17 @@ $p->nagios_die("You should specify three ranges for --critical argument") unless
 # check stuff.
 
 my $hostname = $p->opts->host;
-$hostname =~ /^([a-zA-Z0-9-]*)/;
-my $shortname=$1;
+
+my $nodename = $p->opts->node;
+
+if (!$nodename) {
+    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $nodename = $1;
+}
+
 my $port = $p->opts->port;
 
-my $path = "nodes/rabbit\@$shortname";
+my $path = "nodes/rabbit\@$nodename";
 my $url = "http://$hostname:$port/api/$path";
 
 my $ua = LWP::UserAgent->new(env_proxy=>1);


### PR DESCRIPTION
Added an optional parameter for node name on on check_rabbitmq_server command, as the node name is not always the short version of the host name.
