### PR TITLE
Check if node is actually running before checking resource consumption

### DIFF
--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -132,6 +132,11 @@ if (!$res->is_success) {
 }
 
 my $bodyref = decode_json $res->content;
+
+if (!$bodyref->{'running'}) {
+    $p->nagios_exit(CRITICAL, "Not running: ".$path);
+}
+
 check($p, "Memory", $bodyref->{'mem_used'}, $bodyref->{'mem_limit'}, $warning[0], $critical[0]);
 check($p, "Process", $bodyref->{'proc_used'}, $bodyref->{'proc_total'}, $warning[1], $critical[1]);
 check($p, "FD", $bodyref->{'fd_used'}, $bodyref->{'fd_total'}, $warning[2], $critical[2]);


### PR DESCRIPTION
This also makes check_rabbitmq_server useful to report netsplits in the
underlaying erlang cluster.

Hope you'll find this worthwhile ! In any case, thanks for this plugin set :-)

Cheers,
Marc
