### PR TITLE
Adding SSL support to all checks

### DIFF
--- a/scripts/check_rabbitmq_aliveness
+++ b/scripts/check_rabbitmq_aliveness
@@ -61,6 +61,11 @@ $p->add_arg(spec => 'vhost=s',
     help => "Specify the vhost to test (default: %s)",
     default => "/"
 );
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
@@ -75,7 +80,7 @@ my $hostname=$p->opts->host;
 my $port=$p->opts->port;
 my $vhost=uri_escape($p->opts->vhost);
 
-my $url = "http://$hostname:$port/api/aliveness-test/$vhost";
+my $url = sprintf("http%s://%s:%d/api/aliveness-test/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost);
 
 my $ua = LWP::UserAgent->new(env_proxy=>1);
 $ua->agent($PROGNAME.' ');
@@ -148,6 +153,10 @@ The host to connect to
 =item --port
 
 The port to connect to (default: 55672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
 
 =item --vhost
 

--- a/scripts/check_rabbitmq_objects
+++ b/scripts/check_rabbitmq_objects
@@ -45,6 +45,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
@@ -70,7 +74,7 @@ $ua->credentials("$hostname:$port",
 
 my @calls = ("vhost", "exchange", "binding", "queue", "channel");
 for my $call (@calls) {
-    my $url = sprintf("http://%s:%d/api/%ss", $hostname, $port, $call);
+    my $url = sprintf("http%s://%s:%d/api/%ss", ($p->opts->ssl ? "s" : ""), $hostname, $port, $call);
     my ($code, $result) = request($url);
     if ($code != 200) {
         $p->nagios_exit(CRITICAL, "$result : /api/". $call."s");
@@ -163,6 +167,10 @@ The host to connect to
 =item --port
 
 The port to connect to (default: 55672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
 
 =item --user
 

--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -61,6 +61,11 @@ qq{-c, --critical=INTEGER,INTEGER,INTEGER
    Specify -1 if no critical threshold.},
 );
 
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
@@ -103,7 +108,7 @@ $ua->credentials("$hostname:$port",
     "Management: Web UI", $p->opts->user, $p->opts->password);
 
 
-my $url = sprintf("http://%s:%d/api/overview", $hostname, $port);
+my $url = sprintf("http%s://%s:%d/api/overview", ($p->opts->ssl ? "s" : ""), $hostname, $port);
 my ($retcode, $result) = request($url);
 if ($retcode != 200) {
     $p->nagios_exit(CRITICAL, "$result : /api/overview");
@@ -191,6 +196,10 @@ The host to connect to
 =item --port
 
 The port to connect to (default: 55672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
 
 =item --user
 

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -71,6 +71,11 @@ qq{-c, --critical=INTEGER,INTEGER,INTEGER
    Specify -1 if no critical threshold.},
 );
 
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
@@ -115,7 +120,7 @@ $ua->credentials("$hostname:$port",
     "RabbitMQ Management", $p->opts->user, $p->opts->password);
 
 
-my $url = sprintf("http://%s:%d/api/queues/%s/%s", $hostname, $port, $vhost, $queue);
+my $url = sprintf("http%s://%s:%d/api/queues/%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
 my ($retcode, $result) = request($url);
 if ($retcode != 200) {
     $p->nagios_exit(CRITICAL, "$result : $url");
@@ -203,6 +208,10 @@ The host to connect to
 =item --port
 
 The port to connect to (default: 55672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
 
 =item --user
 

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -79,6 +79,11 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
@@ -105,7 +110,7 @@ if (!$nodename) {
 my $port = $p->opts->port;
 
 my $path = "nodes/rabbit\@$nodename";
-my $url = "http://$hostname:$port/api/$path";
+my $url = sprintf("http%s://%s:%d/api/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $path);
 
 my $ua = LWP::UserAgent->new(env_proxy=>1);
 $ua->agent($PROGNAME.' ');
@@ -215,6 +220,10 @@ The host to connect to
 =item --port
 
 The port to connect to (default: 55672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
 
 =item -w | --warning
 


### PR DESCRIPTION
Enable via the --ssl flag. SSL is disabled by default.
GetOpt spec is wonky because we want support for --no-ssl.
