### PR TITLE
Import %STATUS_TEXT from Nagios::Plugin::Functions

### DIFF
--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -7,7 +7,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(%STATUS_TEXT OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -7,7 +7,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(%STATUS_TEXT OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -9,7 +9,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(%STATUS_TEXT OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;


### PR DESCRIPTION
I branched the from the wrong branch…

In the Nagios::Plugin version available in Ubuntu 10.04 %STATUS_TEXT is
only available in Nagios::Plugin::Functions. In more recent versions of
Nagios::Plugin it imports %STATUS_TEXT from Nagios::Plugin::Functions
and then exports it.

Really fixes jamesc/nagios-plugins-rabbitmq#3
