### PR TITLE
Rename user and host to match .rabbitmqadmin.conf

### DIFF
--- a/scripts/check_rabbitmq_aliveness
+++ b/scripts/check_rabbitmq_aliveness
@@ -39,7 +39,7 @@ my $p = Nagios::Plugin->new(
     blurb => 'This plugin uses the RabbitMQ management aliveness-check to send/receive a message through a vhost.',
 );
 
-$p->add_arg(spec => 'hostname|H=s',
+$p->add_arg(spec => 'hostname|host|H=s',
     help => "Specify the host to connect to",
     required => 1
 );
@@ -48,7 +48,7 @@ $p->add_arg(spec => 'port=i',
     default => 55672
 );
 
-$p->add_arg(spec => 'username|u=s',
+$p->add_arg(spec => 'username|user|u=s',
     help => "Username (default: %s)",
     default => "guest",
 );
@@ -141,7 +141,7 @@ Verbose output
 
 Set a timeout for the check in seconds
 
-=item -H | --hostname
+=item -H | --hostname | --host
 
 The host to connect to
 
@@ -153,7 +153,7 @@ The port to connect to (default: 55672)
 
 The vhost to create the test queue within (default: /)
 
-=item --username
+=item --username | --user
 
 The user to connect as (default: guest)
 

--- a/scripts/check_rabbitmq_objects
+++ b/scripts/check_rabbitmq_objects
@@ -27,7 +27,7 @@ my $p = Nagios::Plugin->new(
     blurb => 'This plugin uses the RabbitMQ management to count various objects.',
 );
 
-$p->add_arg(spec => 'hostname|H=s',
+$p->add_arg(spec => 'hostname|host|H=s',
     help => "Specify the host to connect to",
     required => 1
 );
@@ -36,7 +36,7 @@ $p->add_arg(spec => 'port=i',
     default => 55672
 );
 
-$p->add_arg(spec => 'username|u=s',
+$p->add_arg(spec => 'username|user|u=s',
     help => "Username (default: %s)",
     default => "guest",
 );
@@ -156,7 +156,7 @@ Verbose output
 
 Set a timeout for the check in seconds
 
-=item -H | --hostname
+=item -H | --hostname | --host
 
 The host to connect to
 
@@ -164,7 +164,7 @@ The host to connect to
 
 The port to connect to (default: 55672)
 
-=item --username
+=item --username | --user
 
 The user to connect as (default: guest)
 

--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -26,7 +26,7 @@ my $p = Nagios::Plugin->new(
     blurb => 'This plugin uses the RabbitMQ management to count messages in server.',
 );
 
-$p->add_arg(spec => 'hostname|H=s',
+$p->add_arg(spec => 'hostname|host|H=s',
     help => "Specify the host to connect to",
     required => 1
 );
@@ -35,7 +35,7 @@ $p->add_arg(spec => 'port=i',
     default => 55672
 );
 
-$p->add_arg(spec => 'username|u=s',
+$p->add_arg(spec => 'username|user|u=s',
     help => "Username (default: %s)",
     default => "guest",
 );
@@ -183,7 +183,7 @@ Verbose output
 
 Set a timeout for the check in seconds
 
-=item -H | --hostname
+=item -H | --hostname | --host
 
 The host to connect to
 
@@ -191,7 +191,7 @@ The host to connect to
 
 The port to connect to (default: 55672)
 
-=item --username
+=item --username | --user
 
 The user to connect as (default: guest)
 

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -26,7 +26,7 @@ my $p = Nagios::Plugin->new(
     blurb => 'This plugin uses the RabbitMQ management API to monitor a specific queue.',
 );
 
-$p->add_arg(spec => 'hostname|H=s',
+$p->add_arg(spec => 'hostname|host|H=s',
     help => "Specify the host to connect to",
     required => 1
 );
@@ -35,7 +35,7 @@ $p->add_arg(spec => 'port=i',
     default => 55672
 );
 
-$p->add_arg(spec => 'username|u=s',
+$p->add_arg(spec => 'username|user|u=s',
     help => "Username (default: %s)",
     default => "guest",
 );
@@ -196,7 +196,7 @@ Verbose output
 
 Set a timeout for the check in seconds
 
-=item -H | --hostname
+=item -H | --hostname | --host
 
 The host to connect to
 
@@ -204,7 +204,7 @@ The host to connect to
 
 The port to connect to (default: 55672)
 
-=item --username
+=item --username | --user
 
 The user to connect as (default: guest)
 

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -38,7 +38,7 @@ my $p = Nagios::Plugin->new(
     blurb => 'This plugin uses the RabbitMQ management node API to check server process parameters.',
 );
 
-$p->add_arg(spec => 'hostname|H=s',
+$p->add_arg(spec => 'hostname|host|H=s',
     help => "Specify the host to connect to",
     required => 1
 );
@@ -70,7 +70,7 @@ qq{-c, --critical=INTEGER,INTEGER,INTEGER
    default => "90,90,90",
 );
 
-$p->add_arg(spec => 'username|u=s',
+$p->add_arg(spec => 'username|user|u=s',
     help => "Username (default: %s)",
     default => "guest",
 );
@@ -208,7 +208,7 @@ Verbose output
 
 Set a timeout for the check in seconds
 
-=item -H | --hostname
+=item -H | --hostname | --host
 
 The host to connect to
 
@@ -228,7 +228,7 @@ The critical levels, expressed as a percentage for each of memory, process
 and file descriptor usage.  This field consists of three comma-separated
 integers.  (default: 90,90,90)
 
-=item --username
+=item --username | --user
 
 The user to connect as (default: guest)
 


### PR DESCRIPTION
By renaming host and user we can reuse .rabbitmqadmin.conf with the
extra-opts switch. E.g:
--extra-opts=default@/home/rabbitmq/.rabbitmqadmin.conf
