### PR TITLE
new script: check_rabbitmq_shovels

### DIFF
--- a/scripts/check_rabbitmq_shovels
+++ b/scripts/check_rabbitmq_shovels
@@ -242,10 +242,6 @@ L<http://www.rabbitmq.com/management.html>
 
 =head1 LICENSE
 
-This file is part of nagios-plugins-rabbitmq.
-
-Copyright 2010, Platform 14.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
Hello,

Here is a Nagios plugin to check that all shovels of the given RabbitMQ host are running.
Written for $job, currently used in production.

Regards,

Sébastien Aperghis-Tramoni
