### PR TITLE
Sometimes the API omits fields.

### DIFF
--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -141,7 +141,8 @@ for my $metric (@metrics) {
     my $critical = undef;
     $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} ne -1);
 
-    my $value = $result->{$metric};
+    my $value = 0;
+    $value = $result->{$metric} if defined $result->{$metric};
     my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
     $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
     $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);


### PR DESCRIPTION
This prevents such an error:

  Use of uninitialized value value in sprintf at /etc/icinga-plugins/plugins/check_rabbitmq_queue line 146.
