### PR TITLE
Fix incorrect watermark CRITICAL due to new JSON version

### DIFF
--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -125,7 +125,7 @@ my $bodyref = decode_json $res->content;
 my @checks = ("mem_alarm", "disk_free_alarm");
 
 for my $check (@checks) {
-    if ($bodyref->{$check} eq 'false') {
+    if ($bodyref->{$check} eq 0) {
         $p->add_message(OK, "$check");
     } else {
         $p->add_message(CRITICAL, "$check");


### PR DESCRIPTION
The newly released version 2.90 of JSON.pm on CPAN means that check_rabbitmq_watermark will go CRITICAL on both "mem_alarm" and "disk_alarm".

This is due to the fact that a submodule used by JSON.pm has broken compatibility with the feature that allowed comparisons of JSON booleans to 'true' and 'false' in Perl: http://search.cpan.org/~makamaka/JSON/lib/JSON.pm#DESCRIPTION

Copy & paste of the warning from JSON.pm's release notes:

>   INCOMPATIBLE CHANGE (JSON::XS version 2.90)
> 
>   JSON.pm had patched JSON::XS::Boolean and JSON::PP::Boolean internally
>   on loading time for making these modules inherit JSON::Boolean.
>   But since JSON::XS v3.0 it use Types::Serialiser as boolean class.
>   Then now JSON.pm breaks boolean classe overload features and
>   -support_by_pp if JSON::XS v3.0 or later is installed.
> 
>   JSON::true and JSON::false returned JSON::Boolean objects.
>   For workaround, they return JSON::PP::Boolean objects in this version.
> 
> ```
>   isa_ok(JSON::true, 'JSON::PP::Boolean');
> ```
> 
>   And it discards a feature:
> 
> ```
>   ok(JSON::true eq 'true');
> ```
> 
>   In other word, JSON::PP::Boolean overload numeric only.
> 
> ```
>   ok( JSON::true == 1 );
> ```

We noticed this when Chef helpfully upgraded our JSON.pm and both RabbitMQ nodes starting going CRITICAL some time later (although it took a while to track the problem down)
