### PR TITLE
Fixed typo/copy-paste-error "warning"->critical

### DIFF
--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -67,7 +67,7 @@ qq{-w, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
 $p->add_arg(
     spec => 'critical|c=s',
     help =>
-qq{-c, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
    Critical thresholds specified in order that the metrics are returned.
    Specify -1 if no critical threshold.},
 );


### PR DESCRIPTION
Fixed typo/copy-paste-error "warning"->critical in the help text.
