### PR TITLE
add check_script for monitoring connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Currently we have 5 checks:
 - check\_rabbitmq\_watermark
   - Use the `/api/nodes` API to check to see if mem_alarm has been set to true
 
+- check\_rabbitmq\_connections
+  - Use the `/api/connections` API to gather details of connections used,
+    their state and their throughput
+
 See the relevant POD documentation/man pages for more information on usage.
 
 Licence

--- a/etc/nagios-plugins/config/check_rabbitmq_connections.cfg
+++ b/etc/nagios-plugins/config/check_rabbitmq_connections.cfg
@@ -1,0 +1,9 @@
+define command{
+        command_name    cyb_check_rabbitmq_connections
+        command_line    exec sudo /usr/lib/nagios/plugins-cyb/check_rabbitmq_connections --extra-opts=$ARG1$
+}
+
+define command{
+        command_name    cyb_check_rabbitmq_connections_by_ssh
+        command_line    exec ssh $HOSTADDRESS$ sudo /usr/lib/nagios/plugins-cyb/check_rabbitmq_connections --extra-opts=$ARG1$
+}

--- a/etc/nagios/nrpe.d/check_rabbitmq_connections.cfg
+++ b/etc/nagios/nrpe.d/check_rabbitmq_connections.cfg
@@ -1,0 +1,1 @@
+command[check_nrpe_check_rabbitmq_connections]=exec /usr/lib/nagios/plugins-rabbitmq/check_rabbitmq_connections --extra-opts=$ARG1$

--- a/scripts/check_rabbitmq_connections
+++ b/scripts/check_rabbitmq_connections
@@ -1,0 +1,329 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_connections
+#
+# Use the management APIs to check amount of connections
+#
+use strict;
+use warnings;
+
+use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Nagios::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '1.0';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+my $p = Nagios::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to monitor connections.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 55672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(
+    spec => 'warning|w=s',
+    help =>
+qq{-w, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+$p->add_arg(
+    spec => 'clientuser=s',
+    help => 'Specify the client username to limit the connections for (optional)',
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+my %warning;
+if (defined $p->opts->warning) {
+    my @warning = split(',', $p->opts->warning);
+    $p->nagios_die("You should specify 1 to 4 ranges for --warning argument") unless $#warning < 4;
+
+    $warning{'connections'} = shift @warning;
+    $warning{'connections_notrunning'} = shift @warning;
+    $warning{'receive_rate'} = shift @warning;
+    $warning{'send_rate'} = shift @warning;
+}
+
+my %critical;
+if (defined $p->opts->critical) {
+    my @critical = split(',', $p->opts->critical);
+    $p->nagios_die("You should specify specify 1 to 4 ranges for --critical argument") unless $#critical < 4;
+
+    $critical{'connections'} = shift @critical;
+    $critical{'connections_notrunning'} = shift @critical;
+    $critical{'receive_rate'} = shift @critical;
+    $critical{'send_rate'} = shift @critical;
+}
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+# Different security domains in 2.5 and 2.6
+$ua->credentials("$hostname:$port",
+    "Management: Web UI", $p->opts->username, $p->opts->password);
+$ua->credentials("$hostname:$port",
+    "RabbitMQ Management", $p->opts->username, $p->opts->password);
+
+
+my $url = sprintf("http%s://%s:%d/api/connections", ($p->opts->ssl ? "s" : ""), $hostname, $port);
+my ($retcode, $result) = request($url);
+if ($retcode != 200) {
+    $p->nagios_exit(CRITICAL, "$result : $url");
+}
+
+my $values = {};
+$values->{'connections'} = 0;
+$values->{'connections_notrunning'} = 0;
+$values->{'receive_rate'} = 0;
+$values->{'send_rate'} = 0;
+
+for my $connection (@$result) {
+    if (not defined($p->opts->clientuser) or $p->opts->clientuser eq $connection->{"user"}) {
+        $values->{'connections'}++;
+        $values->{'connections_notrunning'}++ if $connection->{"state"} ne "running";
+        $values->{'receive_rate'} += $connection->{"recv_oct_details"}->{"rate"};
+        $values->{'send_rate'} += $connection->{"send_oct_details"}->{"rate"};
+    }
+}
+
+my @metrics = ("connections", "connections_notrunning", "receive_rate", "send_rate");
+for my $metric (@metrics) {
+    my $warning = undef;
+    $warning = $warning{$metric} if (defined $warning{$metric} and $warning{$metric} ne -1);
+    my $critical = undef;
+    $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} ne -1);
+
+    my $value = 0;
+    $value = $values->{$metric} if defined $values->{$metric};
+    my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+    $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
+    $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);
+}
+
+my ($code, $message) = $p->check_messages(join_all=>', ');
+$p->nagios_exit(return_code => $code, message => $message);
+
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+=head1 NAME
+
+check_rabbitmq_connections - Nagios plugin using RabbitMQ management API to
+count the connections running, their state and optionally limit these checks to
+specific connected client user accounts.
+
+=head1 SYNOPSIS
+
+check_rabbitmq_connections [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to count the number of established
+connections, those that are not in state running and also their throughput. All
+values are published as performance metrics for the check.
+
+Critical and warning thresholds can be set for each of the metric.
+
+It uses Nagios::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 55672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item --pass
+
+The password for the user (default: guest)
+
+=item -w | --warning
+
+The warning levels for each count of connections established, connections
+in a non-running state (flow, blocked), receive rate and send rate.  This
+field consists of one to four comma-separated thresholds.  Specify -1 if
+no threshold for a particular count.
+
+=item -c | --critical
+
+The critical levels for each count of connections established, connections
+in a non-running state (flow, blocked), receive rate and send rate. This
+field consists of one to four comma-separated thresholds.  Specify -1 if
+no threshold for a particular count.
+
+=item --clientuser
+
+Specify the client username to limit the connections checks for.
+
+=back
+
+=head1 THRESHOLD FORMAT
+
+The format of thresholds specified in --warning and --critical arguments
+is defined at <http://nagiosplug.sourceforge.net/developer-guidelines.html#THRESHOLDFORMAT>.
+
+For example to be crtical if more than 5 connections, more than 2 connections not running,
+less than 200b/s received use
+
+--critical=5,2,200,-1
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_connections -H localhost -w 1: -c 1:
+
+This returns a standard Nagios result:
+
+  RABBITMQ_CONNECTIONS CRITICAL - connections CRITICAL (0),
+    connections_notrunning WARNING (0), receive_rate OK (0) send_rate OK (0) |
+    connections=0;;1: connections_notrunning=0;1:; receive_rate=0;; send_rate=0;;
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Nagios::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;


### PR DESCRIPTION
Dear jamesc,

we created a new check to allow validation of connections and their states as we do have to ensure that particular users are connected and are actually pushing or receiving messages from/to RabbitMQ. The script is based on the scripts you already provided and were only slightly adjusted (I'm a bad Perl coder..). It's already used in our infrastructure and it works fine. Now I wonder if this script may be of any use for others and whether you mind merging our commit?

Thanks
Mathias 
