### PR TITLE
check_rabbitmq_overview: gently deal with idle queues

### DIFF
--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -122,13 +122,12 @@ for my $metric (@metrics) {
     my $critical = undef;
     $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} != -1);
 
-    if (ref($result->{'queue_totals'}) eq "HASH")
-	{
+    if (ref($result->{'queue_totals'}) eq "HASH") {
         my $value = $result->{'queue_totals'}->{$metric};
         my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
         $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
         $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);
-	}
+    }
 }
 
 my ($code, $message) = $p->check_messages(join_all=>', ');


### PR DESCRIPTION
 I ran into a little issue with check_rabbitmq_overview: if all queues are idle, the rabbitmq api doesn't return an array for 'queue_totals'. Resulting in this error:
Not a HASH reference at /usr/local/nagios/libexec/check_rabbitmq_overview line 125.

If I view the returned json from the api/overview site:
          'rabbitmq_version' => '3.1.5',
          'erlang_version' => 'R14B04',
          'queue_totals' => []
        };
'queue_totals' is empty which causes the error, I added a check for this case. With this patch check_rabbitmq_overview returns:
./check_rabbitmq_overview --host=xxhost
RABBITMQ_OVERVIEW OK
