### PR TITLE
Issue 24 - Pass credentials to ua via the request object instead of the ...

### DIFF
--- a/scripts/check_rabbitmq_aliveness
+++ b/scripts/check_rabbitmq_aliveness
@@ -91,9 +91,8 @@ my $url = sprintf("http%s://%s:%d/api/aliveness-test/%s", ($p->opts->ssl ? "s" :
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {

--- a/scripts/check_rabbitmq_connections
+++ b/scripts/check_rabbitmq_connections
@@ -114,8 +114,6 @@ my $port=$p->opts->port;
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 
 my $url = sprintf("http%s://%s:%d/api/connections", ($p->opts->ssl ? "s" : ""), $hostname, $port);
 my ($retcode, $result) = request($url);
@@ -159,6 +157,7 @@ $p->nagios_exit(return_code => $code, message => $message);
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {

--- a/scripts/check_rabbitmq_objects
+++ b/scripts/check_rabbitmq_objects
@@ -71,8 +71,6 @@ my $port=$p->opts->port;
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 
 my @calls = ("vhost", "exchange", "binding", "queue", "channel");
 for my $call (@calls) {
@@ -94,6 +92,7 @@ $p->nagios_exit(return_code => OK, message => "Gathered Object Counts");
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {

--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -106,8 +106,6 @@ my $port=$p->opts->port;
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 
 my $url = sprintf("http%s://%s:%d/api/overview", ($p->opts->ssl ? "s" : ""), $hostname, $port);
 my ($retcode, $result) = request($url);
@@ -137,6 +135,7 @@ $p->nagios_exit(return_code => $code, message => $message);
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {

--- a/scripts/check_rabbitmq_partition
+++ b/scripts/check_rabbitmq_partition
@@ -95,9 +95,9 @@ my $url = sprintf("http%s://%s:%d/api/nodes/rabbit\@%s", ($p->opts->ssl ? "s" : 
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
+
 my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -121,8 +121,6 @@ my $queue=$p->opts->queue;
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 
 my $url = sprintf("http%s://%s:%d/api/queues/%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
 my ($retcode, $result) = request($url);
@@ -151,6 +149,7 @@ $p->nagios_exit(return_code => $code, message => $message);
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -121,9 +121,8 @@ my $url = sprintf("http%s://%s:%d/api/%s", ($p->opts->ssl ? "s" : ""), $hostname
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {

--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -100,9 +100,8 @@ my $url = sprintf("http%s://%s:%d/api/nodes/rabbit\@%s", ($p->opts->ssl ? "s" : 
 my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
-$ua->credentials("$hostname:$port",
-    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {


### PR DESCRIPTION
...credentials method

This makes the check backward compatible with RabbitMQ 2.x as the port of 55672 gets
redirected to 15672 later in the request and thus doesn't match the hostname-port combination
that is set in the credentials method.

This should be backported to the rabbitmq-2.x branch as well.
