### PR TITLE
Change Nagios::Plugin with Monitoring::Plugin

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -4,7 +4,7 @@ use Module::Build;
 my $build = Module::Build->new
   (
    dist_name => "nagios-plugins-rabbitmq",
-   dist_version => "2.0.0",
+   dist_version => "2.0.1",
    dist_author => 'James Casey (jamesc.000@gmail.com)',
    dist_abstract => 'Nagios checks for RabbitMQ using the management interface',
    installdirs => 'site',
@@ -20,7 +20,7 @@ my $build = Module::Build->new
                 "Getopt::Long" => 0,
                },
    recommends => {
-                   "Nagios::Plugin" => "0.33",
+                   "Monitoring::Plugin" => "0.37",
                   },
    configure_requires => {
                       "Module::Build" => 0,

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "James Casey (jamesc.000@gmail.com)"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.38, CPAN::Meta::Converter version 2.110930",
+   "generated_by" : "Module::Build version 0.4003, CPAN::Meta::Converter version 2.133380",
    "license" : [
       "apache_2_0"
    ],
@@ -16,23 +16,23 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Module::Build" : 0
+            "Module::Build" : "0"
          }
       },
       "configure" : {
          "requires" : {
-            "Module::Build" : 0
+            "Module::Build" : "0"
          }
       },
       "runtime" : {
          "recommends" : {
-            "Nagios::Plugin" : "0.27"
+            "Monitoring::Plugin" : "0.37"
          },
          "requires" : {
-            "Getopt::Long" : 0,
+            "Getopt::Long" : "0",
             "JSON" : "2.12",
-            "LWP::UserAgent" : 0,
-            "Pod::Usage" : 0,
+            "LWP::UserAgent" : "0",
+            "Pod::Usage" : "0",
             "URI" : "1.35"
          }
       }
@@ -43,5 +43,5 @@
          "http://apache.org/licenses/LICENSE-2.0"
       ]
    },
-   "version" : "v1.0.3"
+   "version" : "v2.0.1"
 }

--- a/META.yml
+++ b/META.yml
@@ -6,14 +6,15 @@ build_requires:
   Module::Build: 0
 configure_requires:
   Module::Build: 0
-generated_by: 'Module::Build version 0.3603'
+dynamic_config: 1
+generated_by: 'Module::Build version 0.4003, CPAN::Meta::Converter version 2.133380'
 license: apache
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
   version: 1.4
 name: nagios-plugins-rabbitmq
 recommends:
-  Nagios::Plugin: 0.33
+  Monitoring::Plugin: 0.37
 requires:
   Getopt::Long: 0
   JSON: 2.12
@@ -22,4 +23,4 @@ requires:
   URI: 1.35
 resources:
   license: http://apache.org/licenses/LICENSE-2.0
-version: v1.1.0
+version: v2.0.1

--- a/scripts/check_rabbitmq_aliveness
+++ b/scripts/check_rabbitmq_aliveness
@@ -12,7 +12,7 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin ;
+use Monitoring::Plugin ;
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -31,8 +31,8 @@ $PROGNAME = basename($0);
 #   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
 
 
-# Instantiate Nagios::Plugin object (the 'usage' parameter is mandatory)
-my $p = Nagios::Plugin->new(
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -141,7 +141,7 @@ check_rabbitmq_aliveness [options] -H hostname
 Use the management interface of RabbitMQ to check that the server is alive.
 It declares a test queue, then publishes and consumes a message.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -215,7 +215,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_connections
+++ b/scripts/check_rabbitmq_connections
@@ -7,8 +7,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
-use Nagios::Plugin::Functions qw(%STATUS_TEXT);
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -20,7 +20,7 @@ $VERSION = '1.0';
 use File::Basename;
 $PROGNAME = basename($0);
 
-my $p = Nagios::Plugin->new(
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -207,7 +207,7 @@ values are published as performance metrics for the check.
 
 Critical and warning thresholds can be set for each of the metric.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -303,7 +303,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_objects
+++ b/scripts/check_rabbitmq_objects
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin ;
+use Monitoring::Plugin ;
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -20,7 +20,7 @@ $VERSION = '1.0';
 use File::Basename;
 $PROGNAME = basename($0);
 
-my $p = Nagios::Plugin->new(
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -154,7 +154,7 @@ Currently the following objects are counted:
 
 =back
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -221,7 +221,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -7,8 +7,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
-use Nagios::Plugin::Functions qw(%STATUS_TEXT);
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -20,7 +20,7 @@ $VERSION = '1.0';
 use File::Basename;
 $PROGNAME = basename($0);
 
-my $p = Nagios::Plugin->new(
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -185,7 +185,7 @@ metrics for the check.
 
 Critical and warning thresholds can be set for each of the metrics.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -265,7 +265,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_partition
+++ b/scripts/check_rabbitmq_partition
@@ -13,7 +13,7 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin ;
+use Monitoring::Plugin ;
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -32,8 +32,8 @@ $PROGNAME = basename($0);
 #   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
 
 
-# Instantiate Nagios::Plugin object (the 'usage' parameter is mandatory)
-my $p = Nagios::Plugin->new(
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -101,7 +101,7 @@ if (!$nodename) {
 }
 
 my $url = sprintf("http%s://%s:%d/api/nodes/%s\@%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $rname, $nodename);
-
+print $url;
 my $ua = LWP::UserAgent->new;
 if (defined $p->opts->proxyurl)
 {
@@ -154,7 +154,7 @@ check_rabbitmq_partition [options] -H hostname
 
 Use the management interface of RabbitMQ to check if a cluster partition has occured.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -228,7 +228,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -7,8 +7,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
-use Nagios::Plugin::Functions qw(%STATUS_TEXT);
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -20,7 +20,7 @@ $VERSION = '1.0';
 use File::Basename;
 $PROGNAME = basename($0);
 
-my $p = Nagios::Plugin->new(
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname --queue queue",
     license => "",
     version => $VERSION,
@@ -198,7 +198,7 @@ published as performance metrics for the check.
 
 Critical and warning thresholds can be set for each of the metrics.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -290,7 +290,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -9,8 +9,8 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin qw(OK CRITICAL WARNING UNKNOWN);
-use Nagios::Plugin::Functions qw(%STATUS_TEXT);
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -31,8 +31,8 @@ $PROGNAME = basename($0);
 #   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
 
 
-# Instantiate Nagios::Plugin object (the 'usage' parameter is mandatory)
-my $p = Nagios::Plugin->new(
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -223,7 +223,7 @@ the host and examines the erlang memory, process and file descriptor usage.
 It provides performance data for each of these variables and allows for
 warning and criticality levels to be specified for each.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -318,7 +318,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html

--- a/scripts/check_rabbitmq_shovels
+++ b/scripts/check_rabbitmq_shovels
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use JSON -support_by_pp;
 use LWP::UserAgent;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 
 
 $::PROGRAM = "check_rabbitmq_shovels";
@@ -22,7 +22,7 @@ MAIN: {
 # run()
 # ---
 sub run {
-    my $np = Nagios::Plugin->new(
+    my $np = Monitoring::Plugin->new(
         plugin  => $::PROGRAM,
         version => $::VERSION,
         blurb   => "check that all the shovels of the given RabbitMQ host "
@@ -234,7 +234,7 @@ diagnostic:
 
 =head1 SEE ALSO
 
-See L<Nagios::Plugin>
+See L<Monitoring::Plugin>
 
 The RabbitMQ management plugin is described at
 L<http://www.rabbitmq.com/management.html>

--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -12,7 +12,7 @@
 use strict;
 use warnings;
 
-use Nagios::Plugin ;
+use Monitoring::Plugin ;
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
@@ -31,8 +31,8 @@ $PROGNAME = basename($0);
 #   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
 
 
-# Instantiate Nagios::Plugin object (the 'usage' parameter is mandatory)
-my $p = Nagios::Plugin->new(
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
     usage => "Usage: %s [options] -H hostname",
     license => "",
     version => $VERSION,
@@ -165,7 +165,7 @@ check_rabbitmq_watermark [options] -H hostname
 
 Use the management interface of RabbitMQ to check if the mem_alarm or disk_free_alarm has been triggered.
 
-It uses Nagios::Plugin and accepts all standard Nagios options.
+It uses Monitoring::Plugin and accepts all standard Nagios options.
 
 =head1 OPTIONS
 
@@ -247,7 +247,7 @@ signify WARNING, UNKNOWN or CRITICAL state.
 
 =head1 SEE ALSO
 
-See Nagios::Plugin(3)
+See Monitoring::Plugin(3)
 
 The RabbitMQ management plugin is described at
 http://www.rabbitmq.com/management.html


### PR DESCRIPTION
Nagios::Plugin is now deprecated and no more maintained. The project is renamed into Monitoring::Plugin
- http://search.cpan.org/~nierlein/Nagios-Plugin-0.37/lib/Nagios/Plugin.pm
- https://www.monitoring-plugins.org/

There is no change in the plugin usage, so I juste renamed the Nagios::Plugin into Monitoring::Plugin in scripts and Build.PL
