### PR TITLE
Add Check RabbitMQ Cluster script

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ etc/nagios/nrpe.d/check_rabbitmq_server.cfg
 etc/nagios/nrpe.d/check_rabbitmq_shovels.cfg
 etc/nagios/nrpe.d/check_rabbitmq_watermark.cfg
 scripts/check_rabbitmq_aliveness
+scripts/check_rabbitmq_cluster
 scripts/check_rabbitmq_connections
 scripts/check_rabbitmq_objects
 scripts/check_rabbitmq_overview

--- a/MANIFEST
+++ b/MANIFEST
@@ -9,6 +9,7 @@ etc/nagios-plugins/config/check_rabbitmq_aliveness.cfg
 etc/nagios-plugins/config/check_rabbitmq_connections.cfg
 etc/nagios-plugins/config/check_rabbitmq_objects.cfg
 etc/nagios-plugins/config/check_rabbitmq_overview.cfg
+etc/nagios-plugins/config/check_rabbitmq_culster.cfg
 etc/nagios-plugins/config/check_rabbitmq_partition.cfg
 etc/nagios-plugins/config/check_rabbitmq_queue.cfg
 etc/nagios-plugins/config/check_rabbitmq_server.cfg
@@ -18,6 +19,7 @@ etc/nagios/nrpe.d/check_rabbitmq_aliveness.cfg
 etc/nagios/nrpe.d/check_rabbitmq_connections.cfg
 etc/nagios/nrpe.d/check_rabbitmq_objects.cfg
 etc/nagios/nrpe.d/check_rabbitmq_overview.cfg
+etc/nagios/nrpe.d/check_rabbitmq_cluster.cfg
 etc/nagios/nrpe.d/check_rabbitmq_partition.cfg
 etc/nagios/nrpe.d/check_rabbitmq_queue.cfg
 etc/nagios/nrpe.d/check_rabbitmq_server.cfg

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Currently we have the following checks:
 - check\_rabbitmq\_partition
   - Use the `/api/nodes` API to check for partitions in a RabbitMQ cluster.
 
+- check\_rabbitmq\_cluster
+  - Use the `/api/nodes` API to check how many node are alived in the cluster.
+
 - check\_rabbitmq\_queue
   - Use the `/api/queue` API to collect the number of pending, ready and
     unacknowledged messages and the number of consumers on a given queue

--- a/etc/nagios-plugins/config/check_rabbitmq_cluster.cfg
+++ b/etc/nagios-plugins/config/check_rabbitmq_cluster.cfg
@@ -1,0 +1,9 @@
+define command{
+        command_name    check_rabbitmq_partition
+        command_line    exec sudo /usr/lib/nagios/plugins/check_rabbitmq_cluster --extra-opts=$ARG1$
+}
+
+define command{
+        command_name    check_rabbitmq_partition_by_ssh
+        command_line    exec ssh $HOSTADDRESS$ sudo /usr/lib/nagios/plugins/check_rabbitmq_cluster --extra-opts=$ARG1$
+}

--- a/etc/nagios/nrpe.d/check_rabbitmq_cluster.cfg
+++ b/etc/nagios/nrpe.d/check_rabbitmq_cluster.cfg
@@ -1,0 +1,1 @@
+command[check_nrpe_check_rabbitmq_partition]=exec /usr/lib/nagios/plugins-rabbitmq/check_rabbitmq_cluster --extra-opts=$ARG1$

--- a/scripts/check_rabbitmq_cluster
+++ b/scripts/check_rabbitmq_cluster
@@ -1,0 +1,248 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_cluster
+#
+# Use the management API to check how many node are alived in the cluster.
+
+use strict;
+use warnings;
+
+use Monitoring::Plugin ;
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '1.0';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+
+##############################################################################
+# define and get the command line options.
+#   see the command line option guidelines at
+#   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
+
+
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to check how many node are in the cluster',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+$p->add_arg(
+    spec => 'warning|w=i',
+    help =>
+qq{-w, --warning=THRESHOLD
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+);
+
+$p->add_arg(
+    spec => 'critical|c=i',
+    help =>
+qq{-c, --critical=THRESHOLD
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $url = sprintf("http%s://%s:%d/api/nodes", ($p->opts->ssl ? "s" : ""), $hostname, $port);
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+        $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+        $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+
+my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
+my $res = $ua->request($req);
+
+if (!$res->is_success) {
+    # Deal with standard error conditions - make the messages more sensible
+    if ($res->code == 400) {
+        my $bodyref = decode_json $res->content;
+        $p->nagios_exit(CRITICAL, $bodyref->{'reason'});
+    }
+    $res->code == 404 and $p->nagios_die("Not found");
+    $res->code == 401 and $p->nagios_die("Access refused");
+    if ($res->code < 200 or $res->code > 400 ) {
+        $p->nagios_exit(CRITICAL, "Received ".$res->status_line);
+    }
+}
+
+my @nodes = @{ decode_json $res->content };
+my $count = 0;
+foreach my $node ( @nodes ) {
+  if ($node->{"name"} && $node->{"running"}) {
+    $count++;
+  }
+}
+
+if ($p->opts->critical && $count <= $p->opts->critical) {
+    $p->nagios_exit( CRITICAL, "The cluster has $count nodes" );
+}
+
+if ($p->opts->warning && $count <= $p->opts->warning) {
+    $p->nagios_exit( WARNING, "The cluster has $count nodes" );
+}
+
+$p->nagios_exit( OK, "The cluster has $count nodes" );
+
+=head1 NAME
+
+check_rabbitmq_cluster - Nagios plugin using RabbitMQ management API to check how many node are alived in the cluster
+
+=head1 SYNOPSIS
+
+check_rabbitmq_partition [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to check if a cluster partition has occured.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item --pass
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_node -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_NODE OK - No Partitions
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+Thierno IB. BARRY
+
+=cut
+
+1;


### PR DESCRIPTION
Hello James,

I added the check_rabbitmq_cluster script. It checks how many node are in the cluster and throw an warning or a critical alert if the node number are bellow the threshold.

Partition are critical, but sometimes we have many nodes and wanted an critical alerte only if we have an critical number of nodes. So I've just writed quickly this scipt to do that. But I'm wondering if it can do this kind of check into the check_rabbitmq_partition or leave is as a stand alone script.

What do you think?

PS: I don't create the nrpe config for this script.