### PR TITLE
check_rabbitmq_watermark: add missing ssl_strict option

### DIFF
--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -69,6 +69,11 @@ $p->add_arg(spec => 'ssl|ssl!',
     default => 0
 );
 
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
 $p->add_arg(spec => 'proxy|proxy!',
     help => "Use environment proxy (default: true)",
     default => 1
@@ -119,6 +124,9 @@ elsif($p->opts->proxy == 1 )
 }
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
+if ($p->opts->ssl) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
 my $req = HTTP::Request->new(GET => $url);
 $req->authorization_basic($p->opts->username, $p->opts->password);
 my $res = $ua->request($req);


### PR DESCRIPTION
As I went through trying the various checks out, I noticed that the `ssl_strict` option was missing on the watermark check.