### PR TITLE
fixed wrond auth header in check_rabbitmq_watermark

### DIFF
--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -101,7 +101,7 @@ my $ua = LWP::UserAgent->new(env_proxy => $p->opts->proxy);
 $ua->agent($PROGNAME.' ');
 $ua->timeout($p->opts->timeout);
 $ua->credentials("$hostname:$port",
-    "Management: Web UI", $p->opts->username, $p->opts->password);
+    "RabbitMQ Management", $p->opts->username, $p->opts->password);
 my $req = HTTP::Request->new(GET => $url);
 my $res = $ua->request($req);
 


### PR DESCRIPTION
authentication in check_rabbitmq_watermark is broken.
check_rabbitmq_partition uses the same api string, but with the right auth. copied auth string to check_rabbitmq_watermark