### PR TITLE
Give plugins a --password-from-file option

### DIFF
--- a/scripts/check_rabbitmq_aliveness
+++ b/scripts/check_rabbitmq_aliveness
@@ -57,6 +57,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'vhost=s',
     help => "Specify the vhost to test (default: %s)",
     default => "/"
@@ -82,6 +86,15 @@ help => "Use proxy url like http://proxy.domain.com:8080",
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # perform sanity checking on command line options
@@ -111,7 +124,7 @@ if ($p->opts->ssl and $ua->can('ssl_opts')) {
     $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
 }
 my $req = HTTP::Request->new(GET => $url);
-$req->authorization_basic($p->opts->username, $p->opts->password);
+$req->authorization_basic($p->opts->username, $password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {
@@ -190,6 +203,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_cluster
+++ b/scripts/check_rabbitmq_cluster
@@ -54,6 +54,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -95,6 +99,16 @@ $p->getopts;
 my $hostname=$p->opts->hostname;
 my $port=$p->opts->port;
 
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
+
+
 my $url = sprintf("http%s://%s:%d/api/nodes", ($p->opts->ssl ? "s" : ""), $hostname, $port);
 my $ua = LWP::UserAgent->new;
 if (defined $p->opts->proxyurl)
@@ -111,7 +125,7 @@ if ($p->opts->ssl and $ua->can('ssl_opts')) {
     $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
 }
 my $req = HTTP::Request->new(GET => $url);
-$req->authorization_basic($p->opts->username, $p->opts->password);
+$req->authorization_basic($p->opts->username, $password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {
@@ -194,6 +208,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_connections
+++ b/scripts/check_rabbitmq_connections
@@ -45,6 +45,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(
     spec => 'warning|w=s',
     help =>
@@ -88,6 +92,14 @@ $p->add_arg(spec => 'proxyurl=s',
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 # perform sanity checking on command line options
 my %warning;
@@ -176,7 +188,7 @@ $p->nagios_exit(return_code => $code, message => $message);
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
-    $req->authorization_basic($p->opts->username, $p->opts->password);
+    $req->authorization_basic($p->opts->username, $password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {
@@ -252,6 +264,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =item -w | --warning
 

--- a/scripts/check_rabbitmq_exchange
+++ b/scripts/check_rabbitmq_exchange
@@ -76,6 +76,10 @@ qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD]]
    Specify -1 if no critical threshold.},
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -96,6 +100,15 @@ $p->add_arg(spec => 'proxyurl=s',
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # perform sanity checking on command line options
@@ -171,7 +184,7 @@ $p->nagios_exit(return_code => $code, message => $message);
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
-    $req->authorization_basic($p->opts->username, $p->opts->password);
+    $req->authorization_basic($p->opts->username, $password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {
@@ -260,6 +273,11 @@ The critical levels for each average rate of confirmed, published_in and
 published_out messages per second for the given period of time.  This field consists of
 one to four comma-separated thresholds.  Specify -1 if no threshold
 for a particular average rate.
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_objects
+++ b/scripts/check_rabbitmq_objects
@@ -45,6 +45,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -65,6 +69,15 @@ $p->add_arg(spec => 'proxyurl=s',
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # perform sanity checking on command line options
@@ -111,7 +124,7 @@ $p->nagios_exit(return_code => OK, message => "Gathered Object Counts");
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
-    $req->authorization_basic($p->opts->username, $p->opts->password);
+    $req->authorization_basic($p->opts->username, $password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {
@@ -199,6 +212,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_partition
+++ b/scripts/check_rabbitmq_partition
@@ -60,6 +60,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -85,6 +89,15 @@ $p->add_arg(spec => 'rname|r=s',
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # perform sanity checking on command line options
@@ -122,7 +135,7 @@ if ($p->opts->ssl and $ua->can('ssl_opts')) {
 }
 
 my $req = HTTP::Request->new(GET => $url);
-$req->authorization_basic($p->opts->username, $p->opts->password);
+$req->authorization_basic($p->opts->username, $password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {
@@ -206,6 +219,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -77,6 +77,10 @@ qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
    Specify -1 if no critical threshold.},
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -97,6 +101,15 @@ $p->add_arg(spec => 'proxyurl=s',
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # perform sanity checking on command line options
@@ -204,7 +217,7 @@ $p->nagios_exit(return_code => $code, message => $message);
 sub request {
     my ($url) = @_;
     my $req = HTTP::Request->new(GET => $url);
-    $req->authorization_basic($p->opts->username, $p->opts->password);
+    $req->authorization_basic($p->opts->username, $password);
     my $res = $ua->request($req);
 
     if (!$res->is_success) {
@@ -293,6 +306,11 @@ The critical levels for each count of messages, messages_ready,
 messages_unacknowledged and consumers.  This field consists of
 one to four comma-separated thresholds.  Specify -1 if no threshold
 for a particular count.
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -80,6 +80,10 @@ $p->add_arg(spec => 'password|p=s',
     default => "guest"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -105,6 +109,15 @@ $p->add_arg(spec => 'rname|r=s',
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # Check we have four values for warning and critical thresholds
@@ -149,7 +162,7 @@ if ($p->opts->ssl and $ua->can('ssl_opts')) {
     $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
 }
 my $req = HTTP::Request->new(GET => $url);
-$req->authorization_basic($p->opts->username, $p->opts->password);
+$req->authorization_basic($p->opts->username, $password);
 my $res = $ua->request($req);
 
 if (!$res->is_success) {
@@ -288,6 +301,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_shovels
+++ b/scripts/check_rabbitmq_shovels
@@ -52,9 +52,23 @@ sub run {
         help    => "Specify the password. Defaults to '%s'.",
         default => "guest",
     );
+    $np->add_arg(spec => 'password-from-file|f=s',
+        help => "Text file from which the password is being read",
+    );
+
 
     # parse options
     $np->getopts;
+
+    my $password = $np->opts->password;
+    if ( my $filename = $np->opts->get('password-from-file') ) {
+        open my $FH, '<', $filename
+            or die "Cannot open '$filename' for reading the password: $!";
+        $password = <$FH>;
+        chomp $password;
+        close $FH;
+    }
+
 
     # --------------------------------------
 
@@ -64,7 +78,7 @@ sub run {
     $json->allow_singlequote->allow_barekey;
 
     # construct the URL authority
-    my $url_authority = $np->opts->username . ":" . $np->opts->password
+    my $url_authority = $np->opts->username . ":" . $password
                       . '@' . $np->opts->hostname . ":" . $np->opts->port;
 
     # fetch the list of shovels
@@ -190,6 +204,11 @@ Print a more detailed help screen, then exit.
 =item B<-V>, B<--version>
 
 Print the program name and version, then exit.
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 

--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -64,6 +64,10 @@ $p->add_arg(spec => 'vhost=s',
     default => "/"
 );
 
+$p->add_arg(spec => 'password-from-file|f=s',
+    help => "Text file from which the password is being read",
+);
+
 $p->add_arg(spec => 'ssl|ssl!',
     help => "Use SSL (default: false)",
     default => 0
@@ -90,6 +94,15 @@ $p->add_arg(spec => 'rname|r=s',
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
+
+my $password = $p->opts->password;
+if ( my $filename = $p->opts->get('password-from-file') ) {
+    open my $FH, '<', $filename
+        or die "Cannot open '$filename' for reading the password: $!";
+    $password = <$FH>;
+    chomp $password;
+    close $FH;
+}
 
 
 # perform sanity checking on command line options
@@ -222,6 +235,11 @@ The user to connect as (default: guest)
 =item -p | --password
 
 The password for the user (default: guest)
+
+=item -f | --password-from-file
+
+The name of a file to read the password from.
+The password is read from the first line.
 
 =back
 


### PR DESCRIPTION
that way you can avoid passing passwords on the command line, which
on linux can be viewed by any user who is logged in at the same time
that the process runs.