### PR TITLE
If a queue is not found, report an UNKNOWN status

### DIFF
--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -95,8 +95,9 @@ $p->add_arg(spec => 'proxyurl=s',
     help => "Use proxy url like http://proxy.domain.com:8080",
 );
 
-$p->add_arg(spec => 'ignore',
-    help => "Ignore alerts if queue does not exist",
+$p->add_arg(spec => 'ignore|ignore!',
+    help => "Ignore alerts if queue does not exist (default: false)",
+    default => 0
 );
 
 # Parse arguments and process standard ones (e.g. usage, help, version)

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -154,6 +154,9 @@ if ($queue eq "all"){
     $url = sprintf("http%s://%s:%d/api/queues/%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
 }
 my ($retcode, $result) = request($url);
+if ($retcode == 404) {
+    $p->nagios_exit(UNKNOWN, "$result : $url");
+}
 if ($retcode != 200) {
     $p->nagios_exit(CRITICAL, "$result : $url");
 }

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -95,6 +95,10 @@ $p->add_arg(spec => 'proxyurl=s',
     help => "Use proxy url like http://proxy.domain.com:8080",
 );
 
+$p->add_arg(spec => 'ignore',
+    help => "Ignore alerts if queue does not exist",
+);
+
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
@@ -131,6 +135,7 @@ my $port=$p->opts->port;
 my $vhost=uri_escape($p->opts->vhost);
 my $queue=$p->opts->queue;
 my $filter=$p->opts->filter;
+my $ignore=$p->opts->ignore;
 
 my $ua = LWP::UserAgent->new;
 if (defined $p->opts->proxyurl)
@@ -154,8 +159,8 @@ if ($queue eq "all"){
     $url = sprintf("http%s://%s:%d/api/queues/%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
 }
 my ($retcode, $result) = request($url);
-if ($retcode == 404) {
-    $p->nagios_exit(UNKNOWN, "$result : $url");
+if ($retcode == 404 && $ignore) {
+    $p->nagios_exit(OK, "$result : $url");
 }
 if ($retcode != 200) {
     $p->nagios_exit(CRITICAL, "$result : $url");
@@ -298,6 +303,12 @@ The critical levels for each count of messages, messages_ready,
 messages_unacknowledged and consumers.  This field consists of
 one to four comma-separated thresholds.  Specify -1 if no threshold
 for a particular count.
+
+=item --ignore
+
+If the queue specified does not exist, this option ignores 
+CRITICAL alerts and returns a status of OK.  Useful for scenarios
+where queue existence is optional.
 
 =back
 


### PR DESCRIPTION
If a 404 response code is returned, we don't know that status of the queue, so report an unknown. 

This is helpful for (at least) the following reasons:
  1.  Helps identify configuration errors vs actual CRITICAL statuses.  Namely typos.
  2.  Some software frameworks that use RabbitMQ as the transport (i.e. MassTransit) will create an _error queue to store messages that cause errors.  This change allows the creation of Nagios services that query for an _error queue, but does not report a CRITICAL is the queue has not yet been created.