### PR TITLE
Add '.' to character class for hostnames (to accommodate FQDNs)

### DIFF
--- a/scripts/check_rabbitmq_partition
+++ b/scripts/check_rabbitmq_partition
@@ -101,7 +101,7 @@ my $nodename = $p->opts->node;
 my $rname = $p->opts->rname;
 
 if (!$nodename) {
-    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $hostname =~ /^([a-zA-Z0-9-.]+)/;
     $nodename = $1;
 }
 

--- a/scripts/check_rabbitmq_server
+++ b/scripts/check_rabbitmq_server
@@ -124,7 +124,7 @@ my $nodename = $p->opts->node;
 my $rname = $p->opts->rname;
 
 if (!$nodename) {
-    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $hostname =~ /^([a-zA-Z0-9-.]*)/;
     $nodename = $1;
 }
 

--- a/scripts/check_rabbitmq_watermark
+++ b/scripts/check_rabbitmq_watermark
@@ -107,7 +107,7 @@ my $nodename = $p->opts->node;
 my $rname = $p->opts->rname;
 
 if (!$nodename) {
-    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $hostname =~ /^([a-zA-Z0-9-.]*)/;
     $nodename = $1;
 }
 


### PR DESCRIPTION
I had an issue where the script wasn't automatically setting nodename to the same as hostname if the value was a FQDN.

This request adds '.' to the character class for hostnames (to accommodate fully qualified hostnames, which are legal if you set the erlang options for long hostnames).

I also changed the regex to `[stuff]+` instead of `[stuff]*`