### PR TITLE
Optional 'average' flag

### DIFF
--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -102,6 +102,11 @@ $p->add_arg(spec => 'ignore|ignore!',
     default => 0
 );
 
+$p->add_arg(spec => 'average',
+    help => "Return performance metrics as an average over the number of queues checked. (default: true)",
+    default => 1
+);
+
 # Parse arguments and process standard ones (e.g. usage, help, version)
 $p->getopts;
 
@@ -139,6 +144,8 @@ my $vhost=uri_escape($p->opts->vhost);
 my $queue=$p->opts->queue;
 my $filter=$p->opts->filter;
 my $ignore=$p->opts->ignore;
+my $average=$p->opts->average;
+
 
 my $ua = LWP::UserAgent->new;
 if (defined $p->opts->proxyurl)
@@ -193,7 +200,15 @@ for my $metric (@metrics) {
             
             $p->add_message($code, sprintf("$queue->{name} : $metric ".$STATUS_TEXT{$code}." (%d)", $value)) unless $code == 0;
         }
-        $p->add_perfdata(label=>$metric, value=>sprintf("%.4f", $sum_metric_value/$nb_matched_queues), warning=>$warning, critical=> $critical);
+
+        my $metric_value = 0;
+        if($average){
+            $metric_value = $sum_metric_value/$nb_matched_queues;
+        } else {
+            $metric_value = $sum_metric_value;
+        }
+
+        $p->add_perfdata(label=>$metric, value=>sprintf("%.4f", $metric_value), warning=>$warning, critical=> $critical);
     } else{
         my $value = 0;
         $value = $result->{$metric} if defined $result->{$metric};
@@ -312,6 +327,11 @@ for a particular count.
 If the queue specified does not exist, this option ignores 
 CRITICAL alerts and returns a status of OK.  Useful for scenarios
 where queue existence is optional.
+
+=item --average
+
+Display performance metrics as an average of the messages in the queues
+per metric over the total number of queues checked. (Defaults: true)
 
 =back
 

--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -102,9 +102,9 @@ $p->add_arg(spec => 'ignore|ignore!',
     default => 0
 );
 
-$p->add_arg(spec => 'average',
-    help => "Return performance metrics as an average over the number of queues checked. (default: true)",
-    default => 1
+$p->add_arg(spec => 'total_values|total_values!',
+    help => "Return performance metrics as a total sum of all the messages in a queue. Defaults to an average over the number of queues checked. (default: false)",
+    default => 0
 );
 
 # Parse arguments and process standard ones (e.g. usage, help, version)
@@ -144,7 +144,7 @@ my $vhost=uri_escape($p->opts->vhost);
 my $queue=$p->opts->queue;
 my $filter=$p->opts->filter;
 my $ignore=$p->opts->ignore;
-my $average=$p->opts->average;
+my $total_values=$p->opts->total_values;
 
 
 my $ua = LWP::UserAgent->new;
@@ -202,10 +202,10 @@ for my $metric (@metrics) {
         }
 
         my $metric_value = 0;
-        if($average){
-            $metric_value = $sum_metric_value/$nb_matched_queues;
-        } else {
+        if($total_values){
             $metric_value = $sum_metric_value;
+        } else {
+            $metric_value = $sum_metric_value/$nb_matched_queues;
         }
 
         $p->add_perfdata(label=>$metric, value=>sprintf("%.4f", $metric_value), warning=>$warning, critical=> $critical);


### PR DESCRIPTION
Adds average flag to queue script. Defaults to true so existing uses of the script will continue to behave as normal. If set to false, performance metrics are returned as the sum of the messages on each queue for each metric.