### PR TITLE
Fix case when filter returns no queue to work on

### DIFF
--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -181,25 +181,27 @@ for my $metric (@metrics) {
         my $message = "";
         my $nb_matched_queues = 0;
         my $sum_metric_value = 0;
+        my $total_value = 0;
         for my $queue (@$result){
             next if $queue->{name} !~ /$filter/i;
             my $value = 0;
             $value = $queue->{$metric} if defined $queue->{$metric};
             my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
             push @values, $code;
-            
+
             $nb_matched_queues++;
             $sum_metric_value += $value;
-            
+            $total_value = $sum_metric_value/$nb_matched_queues;
+
             $p->add_message($code, sprintf("$queue->{name} : $metric ".$STATUS_TEXT{$code}." (%d)", $value)) unless $code == 0;
         }
-        $p->add_perfdata(label=>$metric, value=>sprintf("%.4f", $sum_metric_value/$nb_matched_queues), warning=>$warning, critical=> $critical);
+        $p->add_perfdata(label=>$metric, value=>sprintf("%.4f", $total_value), warning=>$warning, critical=> $critical);
     } else{
         my $value = 0;
         $value = $result->{$metric} if defined $result->{$metric};
         my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
         push @values, $code;
-        
+
         $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
         $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);
     }


### PR DESCRIPTION
If a Q does not exist, the plugin will fail with a devide by zero exception.
In our use case, we sometimes monitor queues that will be deleted for a while before added back.
This will avoid failing with the non descriptive 'Illegal division by zero' error.
```sh
$> /opt/plugins/check_rabbitmq_queue -H $HOSTNAME --port=$PORT -u $username -p $password --filter NON_EXISTING_QUEUE -c 400,400,400
Illegal division by zero at /opt/plugins/check_rabbitmq_queue line 196.
```