### PR TITLE
Fix to handle shovels in connections list

### DIFF
--- a/scripts/check_rabbitmq_connections
+++ b/scripts/check_rabbitmq_connections
@@ -149,9 +149,9 @@ $values->{'send_rate'} = 0;
 for my $connection (@$result) {
     if (not defined($p->opts->clientuser) or $p->opts->clientuser eq $connection->{"user"}) {
         $values->{'connections'}++;
-        $values->{'connections_notrunning'}++ if $connection->{"state"} ne "running";
-        $values->{'receive_rate'} += $connection->{"recv_oct_details"}->{"rate"};
-        $values->{'send_rate'} += $connection->{"send_oct_details"}->{"rate"};
+        $values->{'connections_notrunning'}++ if ((not defined $connection->{"state"}) || ($connection->{"state"} ne "running"));
+        $values->{'receive_rate'} += $connection->{"recv_oct_details"}->{"rate"} if (defined $connection->{"recv_oct_details"}->{"rate"});
+        $values->{'send_rate'} += $connection->{"send_oct_details"}->{"rate"} if (defined $connection->{"send_oct_details"}->{"rate"});
     }
 }
 


### PR DESCRIPTION
When shovels are used the connection state and oct_details are empty so the check_rabbitmq_connections will display perl errors. This fix handles these errors so the output is correct for both shovel and normal connections.