### PR TITLE
Fixing: If there are no queues, the check returns invalid perfdata

### DIFF
--- a/scripts/check_rabbitmq_overview
+++ b/scripts/check_rabbitmq_overview
@@ -141,7 +141,7 @@ for my $metric (@metrics) {
     $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} != -1);
 
     if (ref($result->{'queue_totals'}) eq "HASH") {
-        my $value = $result->{'queue_totals'}->{$metric};
+        my $value = defined $result->{'queue_totals'}->{$metric} ? $result->{'queue_totals'}->{$metric} : 0;
         my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
         $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
         $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);


### PR DESCRIPTION
Previously, if there is no throughput through the rabbit cluster, the check would return ` messages=;; messages_ready=;; messages_unacknowledged=;;` as perfdata and throw several `Use of uninitialized value $value in sprintf at /omd/sites/default/local/lib/nagios/plugins/check_rabbitmq_overview line 146.` errors.