### PR TITLE
speed up check_rabbitmq_objects: reduce amount of metadata requested

### DIFF
--- a/scripts/check_rabbitmq_objects
+++ b/scripts/check_rabbitmq_objects
@@ -92,8 +92,11 @@ if ($p->opts->ssl and $ua->can('ssl_opts')) {
 }
 
 my @calls = ("vhost", "exchange", "binding", "queue", "channel");
+my %col = ("binding" => "vhost", "*" => "name");
+
 for my $call (@calls) {
-    my $url = sprintf("http%s://%s:%d/api/%ss", ($p->opts->ssl ? "s" : ""), $hostname, $port, $call);
+    my $url = sprintf("http%s://%s:%d/api/%ss?columns=%s",
+                      ($p->opts->ssl ? "s" : ""), $hostname, $port, $call, $col{$call} || $col{'*'});
     my ($code, $result) = request($url);
     if ($code != 200) {
         $p->nagios_exit(CRITICAL, "$result : /api/". $call."s");


### PR DESCRIPTION
Parsing big JSON documents can take a long time, and we only want
the number of objects.  "name" is a valid attribute for all
endpoints except bindings, so we ask for "vhost" instead for that case.

On our OpenStack using RabbitMQ, CPU time for this check was reduced
from 52 seconds to 2 seconds.