### PR TITLE
Do not uri escape on default vhost (slash), fixes queue check

### DIFF
--- a/scripts/check_rabbitmq_queue
+++ b/scripts/check_rabbitmq_queue
@@ -14,7 +14,7 @@ use URI::Escape;
 use JSON;
 
 use vars qw($VERSION $PROGNAME  $verbose $timeout);
-$VERSION = '2.0.3';
+$VERSION = '2.0.4';
 
 # get the base name of this script for use in the examples
 use File::Basename;
@@ -135,7 +135,8 @@ if (defined $p->opts->critical) {
 
 my $hostname=$p->opts->hostname;
 my $port=$p->opts->port;
-my $vhost=uri_escape($p->opts->vhost);
+my $vhost='/';
+$vhost.=uri_escape($p->opts->vhost) if $p->opts->vhost ne "/";
 my $queue=$p->opts->queue;
 my $filter=$p->opts->filter;
 my $ignore=$p->opts->ignore;
@@ -157,9 +158,9 @@ if ($p->opts->ssl and $ua->can('ssl_opts')) {
 
 my $url = "";
 if ($queue eq "all"){
-    $url = sprintf("http%s://%s:%d/api/queues/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost);
+    $url = sprintf("http%s://%s:%d/api/queues%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost);
 } else{
-    $url = sprintf("http%s://%s:%d/api/queues/%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
+    $url = sprintf("http%s://%s:%d/api/queues%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
 }
 my ($retcode, $result) = request($url);
 if ($retcode == 404 && $ignore) {


### PR DESCRIPTION
The plugin does a uri_escape on the vhost, which is by default set to `/`. This then creates a `%2F` character instead of the `/` slash character, failing to find the URL:

```
$ /usr/lib/nagios/plugins/check_rabbitmq_queue.pl -H localhost --port 15672 --username monitoring --password secret
RABBITMQ_QUEUE CRITICAL - Access Refused : http://localhost:15672/api/queues/%2F
```

With this PR, this is fixed and only does a uri_escape on actual vhost names, not on `/`. 

```
$ /tmp/check_rabbitmq_queue.pl -H localhost --port 15672 --username monitoring --password secret
RABBITMQ_QUEUE OK - All queues under the thresholds | messages=0.8636;; messages_ready=0.8636;; messages_unacknowledged=0.0000;; consumers=0.5682;;
```


This probably also fixes #106 .